### PR TITLE
feat(#35): NaverMap 마커 이미지 404 대응 및 상태 기반 파라미터 관리 리팩토링

### DIFF
--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -78,12 +78,14 @@ function NaverMap({ cn }: NaverMapProps) {
     restaurants.pages[0].contents.forEach(
       ({ id, latitude, longitude, visitedCelebrities }) => {
         if (markersRef.current.has(id)) return;
+
         const newMarker = new naver.maps.Marker({
           position: new naver.maps.LatLng(latitude, longitude),
           map: mapRef.current!,
           icon: {
             content: `<img
               src="${visitedCelebrities[0].profileImageUrl}"
+              onerror="this.onerror=null;this.src='https://placehold.co/20x20/DEDEDE/FFFFFF/png';"
               class="relative bottom-[19px] right-[19px] h-[38px] min-h-[38px] w-[38px] min-w-[38px] flex-none rounded-full border-[3px] border-white object-cover"
             />`,
           },


### PR DESCRIPTION
## 주요 변경사항
- NaverMap 컴포넌트에서 쿼리 파라미터를 상태로 관리하도록 리팩토링
- 마커 이미지가 404(존재하지 않을 때)일 경우, https://placehold.co/20x20/DEDEDE/FFFFFF/png 대체 이미지가 노출되도록 onerror 속성 추가
- 마커 관리 로직을 useRef로 변경하여 불필요한 렌더링 방지
- 마커 렌더링 시 기존 마커 초기화 처리 추가
## 테스트 방법
- 지도 영역을 이동하거나 새로고침하여 쿼리 파라미터가 정상적으로 상태에 반영되는지 확인
- 연예인 프로필 이미지가 없는 경우(404) 대체 이미지가 정상적으로 노출되는지 확인
## 기타
- 추가 개선사항이나 버그가 있다면 코멘트 부탁드립니다!